### PR TITLE
Fixed some things, made links easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ Don't go into edit mode to resize it - just use the transform
 
 With this, you should be able to semi-accurately place portals.
 
+To check the orientation:
+Local Y should be up, Z should be facing outwards.
+
 I'm not quite sure it works completely accurately, and if not what's responsible, but it's a start.
 
 - **Link Name** The name displayed on the portal.

--- a/README.md
+++ b/README.md
@@ -54,16 +54,35 @@ This addon was tested under Ubuntu/Linux and Windows. Your feedback is welcome!
 - **Display Mode** Select 2D, Rift, SBS, SBSR mode
 - **Rate** Server update rate
 - **JanusVR FullScreen** Starts JanusVR in fullscreen mode
-- **Winow Size** Launch JanusVR with the specified window dimensions
+- **Window Size** Launch JanusVR with the specified window dimensions
 
 ###Objects
 
 __*These attributes are all set on a per object basis__
 
-_**Mesh Objects**_
+_**Mesh Objects/Common**_
+
+- **Object Type** For the most part, should be "Object (model)". However, it can be used to allow making placeholder objects with meshes.
+- **js\_id** Specify js\_id for object here, blank will give a default numeric id
+
+_**Mesh Objects/Link**_
+
+When making one of these, start off with a newly created Plane.
+
+Don't go into edit mode to resize it - just use the transform
+ (the exporter won't pick up on mesh resizing, the plane itself is just a placeholder)
+
+With this, you should be able to semi-accurately place portals.
+
+I'm not quite sure it works completely accurately, and if not what's responsible, but it's a start.
+
+- **Link Name** The name displayed on the portal.
+- **Link URL** Since (unlike the old "text as portal" system) link objects don't directly hold text, the URL is put here.
+- **Active** If false, ``active="false"`` is set.
+
+_**Mesh Objects/Mesh**_
 
 - **Export Format** Select Wavefront (.obj) or Collada (.dae) export format
-- **js_id** Specify js_id for object here, blank will give a default numeric id
 - **Collision** Enable collision for this object
 - **Locked** Lock this object
 - **Visible** Draw this item in the Janus room (setting to false with collision set to true is useful for proxy collision geometry)
@@ -78,13 +97,22 @@ _**Mesh Objects**_
   - **Vertex Shader** Set path to Vertex Shader (use absolute paths)
 
 _**Sound Objects (use speaker in Blender)**_
+
 - **Sound** Set path to sound file (use absolute paths)
-- **js id** js_id for sound object
+- **js\_id** js\_id for sound object
 - **Distance** Distance at which sound plays at full volume
 - **XY1** X and Z positions for first corner of trigger rectangle
 - **XY2** X and Z positions for second corner of trigger rectangle
 - **Loop** loop sound
 - **Place once** play the sound only the first time triggered per user session
+
+_**Text Objects**_
+
+Text objects don't have any properties as such, but there are the following things to note:
+
+1. Text is created for single-line, Paragraph for multi-line.
+2. It seems JanusVR ignores the lines anyway, so this is fine.
+3. The old "beginning with http creates link" behavior still exists - not exactly sublime.
 
 ###Room
 
@@ -136,6 +164,9 @@ Use Apply Rotation under export options
 
 ###The objects are scaleded incorrectly
 Use Apply Scale under export options
+
+###I used it and it messed with all my rotations and scales
+Turn off Apply Rotation and Apply Scale under export options
 
 ###Getting errors about file paths
 Always use absolute paths, either disable "use relative paths" under user preferences or unclick the relative path checkbox when selecting your file.

--- a/__init__.py
+++ b/__init__.py
@@ -59,6 +59,11 @@ class ToolPanel(Panel):
 		self.layout.operator("fire.html", icon_value=custom_icons["custom_icon"].icon_id)
 		if context.scene.roomhash:
 			self.layout.prop(context.scene, "roomhash")
+		# The licence of my contributions is public domain, too,
+		# but I would prefer if this note stuck around.
+		# Including the "Who needs sleep?" bit. - 20kdc, who needs sleep. (It's 2AM.)
+		self.layout.label("Warning: Export may apply transforms.")
+		self.layout.label("Save before usage. Who needs sleep?")
 		self.layout.operator("export_scene.html")
 
 Scene.janus_ipfs = BoolProperty(name="Use IPFS", default=False)
@@ -66,8 +71,8 @@ Scene.janus_gateway = BoolProperty(name="IPFS Gateway", default=False)
 Scene.janus_ipns = BoolProperty(name="IPNS", default=False)
 Scene.janus_ipnsname = StringProperty(name="", default="myroom")
 
-Scene.janus_apply_rot = BoolProperty(name="Apply Rotation", default=True)
-Scene.janus_apply_scale = BoolProperty(name="Apply Scale", default=True)
+Scene.janus_apply_rot = BoolProperty(name="Apply Rotation", default=False)
+Scene.janus_apply_scale = BoolProperty(name="Apply Scale", default=False)
 Scene.janus_apply_pos = BoolProperty(name="Apply Position", default=False)
 Scene.janus_unpack = BoolProperty(name="Unpack Textures", default=True)
 
@@ -110,6 +115,10 @@ class RunSettingsPanel(Panel):
 
 Scene.janus_object_export = EnumProperty(name="", default=".obj", items=((".obj", "Wavefront", "Wavefront object files"),(".dae", "Collada", "Collada files")))
 Object.janus_object_jsid = StringProperty(name="js_id", default="")
+Object.janus_object_objtype = EnumProperty(name="", default="JOT_OBJECT", items=(("JOT_NONE", "No Export", "Don't export this object."), ("JOT_OBJECT", "Object (model)", "<Object>"), ("JOT_LINK", "Link (portal)", "<Link>")))
+Object.janus_object_link_name = StringProperty(name="Link Name", default="")
+Object.janus_object_link_url = StringProperty(name="Link URL", default="")
+Object.janus_object_active = BoolProperty(name="Active", default=True)
 Object.janus_object_collision = BoolProperty(name="Collision", default=True)
 Object.janus_object_locked = BoolProperty(name="Locked", default=False)
 Object.janus_object_lighting = BoolProperty(name="Lighting", default=True)
@@ -139,31 +148,41 @@ class ObjectPanel(Panel):
 	def draw(self, context):
 		
 		if context.object.type == "MESH":
-			self.layout.prop(context.scene, "janus_object_export")
-			self.layout.prop(context.object, "janus_object_jsid")
-			self.layout.prop(context.object, "janus_object_collision")
-			self.layout.prop(context.object, "janus_object_locked")
-			self.layout.prop(context.object, "janus_object_lighting")
-			self.layout.prop(context.object, "janus_object_visible")
-			if context.object.janus_object_visible:
-				self.layout.prop(context.object, "janus_object_color_active")
-				if context.object.janus_object_color_active:
-					self.layout.prop(context.object, "janus_object_color")
+			self.layout.prop(context.object, "janus_object_objtype")
+			if context.object.janus_object_objtype != "JOT_NONE":
+				self.layout.prop(context.object, "janus_object_jsid")
+			if context.object.janus_object_objtype == "JOT_OBJECT":
+				self.layout.prop(context.scene, "janus_object_export")
+				self.layout.prop(context.object, "janus_object_collision")
+				self.layout.prop(context.object, "janus_object_locked")
+				self.layout.prop(context.object, "janus_object_lighting")
+				self.layout.prop(context.object, "janus_object_visible")
+				if context.object.janus_object_visible:
+					self.layout.prop(context.object, "janus_object_color_active")
+					if context.object.janus_object_color_active:
+						self.layout.prop(context.object, "janus_object_color")
 
-			self.layout.prop(context.object, "janus_object_websurface")
-			if context.object.janus_object_websurface:
-				self.layout.prop(context.object, "janus_object_websurface_url")
-				self.layout.label("Width & Height")
-				self.layout.prop(context.object, "janus_object_websurface_size")
+				self.layout.prop(context.object, "janus_object_websurface")
+				if context.object.janus_object_websurface:
+					self.layout.prop(context.object, "janus_object_websurface_url")
+					self.layout.label("Width & Height")
+					self.layout.prop(context.object, "janus_object_websurface_size")
 
-			self.layout.label("Cull Face")
-			self.layout.prop(context.object, "janus_object_cullface")
-			
-			self.layout.prop(context.object, "janus_object_shader_active")
-			if context.object.janus_object_shader_active:
-				self.layout.prop(context.object, "janus_object_shader_frag")
-				self.layout.prop(context.object, "janus_object_shader_vert")
-
+				self.layout.label("Cull Face")
+				self.layout.prop(context.object, "janus_object_cullface")
+				
+				self.layout.prop(context.object, "janus_object_shader_active")
+				if context.object.janus_object_shader_active:
+					self.layout.prop(context.object, "janus_object_shader_frag")
+					self.layout.prop(context.object, "janus_object_shader_vert")
+			elif context.object.janus_object_objtype == "JOT_LINK":
+				self.layout.label("Use a standard plane,")
+				self.layout.label(" and adjust the transform.")
+				self.layout.label("(Don't edit the mesh itself)")
+				self.layout.prop(context.object, "janus_object_link_name")
+				self.layout.prop(context.object, "janus_object_link_url")
+				self.layout.prop(context.object, "janus_object_active")
+		
 		elif context.object.type=="SPEAKER":
 			self.layout.prop(context.object, "janus_object_sound")
 			self.layout.prop(context.object, "janus_object_jsid")

--- a/html.py
+++ b/html.py
@@ -32,22 +32,16 @@ class Tag:
 			if self.tag=="Object":
 				w(" ")
 			w(">")
-			
-		if nice and len(self.sub)>0:
-			w("\n")
-
+		# self.sub must not be indented, as Text objects are sensitive to this under some conditions (tried on JanusVR 54.1 under Wine 1.9.23) and will result in bells.
+		# Maybe that's a bug in JanusVR, maybe that's a bug in Wine, maybe that's a bug here, in any case, this works around it.
 		for s in self.sub:
 			if isinstance(s, str):
-				if nice:
-					w(indent*(level+1))
 				w(s)
-				if nice:
-					w("\n")
 			else:
 				#if loop<n: prevent recursion
 				s.write(w, nice, level+(0 if self.single else 1), indent, loop+1)
 				
-		if nice and not self.single:
+		if len(self.sub)==0 and nice and not self.single:
 			w(indent*(level))
 		if not len(self.sub)==0 and not self.single:
 			w("</%s>" % self.tag)

--- a/vr_export.py
+++ b/vr_export.py
@@ -136,7 +136,7 @@ def write_html(scene, filepath, path_mode):
 			assetimage = Tag("AssetImage", attr=[("id",sky[1]), ("src",skyname)])
 			if not assetimage in assets:
 				assets(assetimage)
-				shutil.copyfile(src=sky[0], dst=os.path.join(filepath, skyname))	
+				shutil.copyfile(src=bpy.path.abspath(sky[0]), dst=os.path.join(filepath, skyname))	
 
 	if scene.janus_room_script_active:	
 		script_list = [scene.janus_room_script1,scene.janus_room_script2,scene.janus_room_script3,scene.janus_room_script4]
@@ -146,7 +146,7 @@ def write_html(scene, filepath, path_mode):
 				assetscript = Tag("AssetScript", attr=[("src",scriptname)])
 				if not assetscript in assets:
 					assets(assetscript)
-					shutil.copyfile(src=script_entry, dst=os.path.join(filepath, scriptname))
+					shutil.copyfile(src=bpy.path.abspath(script_entry), dst=os.path.join(filepath, scriptname))
 
 	if scene.janus_room_shader_active:		
 		if scene.janus_room_shader_frag != "":
@@ -161,9 +161,9 @@ def write_html(scene, filepath, path_mode):
 		if not assetshader in assets:
 			assets(assetshader)
 			if fragname:
-				shutil.copyfile(src=scene.janus_room_shader_frag, dst=os.path.join(filepath, fragname))
+				shutil.copyfile(src=bpy.path.abspath(scene.janus_room_shader_frag), dst=os.path.join(filepath, fragname))
 			if vertname:
-				shutil.copyfile(src=scene.janus_room_shader_vert, dst=os.path.join(filepath, vertname))						
+				shutil.copyfile(src=bpy.path.abspath(scene.janus_room_shader_vert), dst=os.path.join(filepath, vertname))						
 				
 	room = Tag("Room", attr)
 	
@@ -283,9 +283,9 @@ def write_html(scene, filepath, path_mode):
 						assetshader = Tag("AssetShader", attr=[("id",fragname),("src",fragname),("vertex_src",vertname)])
 						if not assetshader in assets:
 								assets(assetshader)
-								shutil.copyfile(src=o.janus_object_shader_frag, dst=os.path.join(filepath, fragname))
+								shutil.copyfile(src=bpy.path.abspath(o.janus_object_shader_frag), dst=os.path.join(filepath, fragname))
 								if vertname != "":
-									shutil.copyfile(src=o.janus_object_shader_vert, dst=os.path.join(filepath, vertname))
+									shutil.copyfile(src=bpy.path.abspath(o.janus_object_shader_vert), dst=os.path.join(filepath, vertname))
 						attr += [("shader_id", fragname)]
 				
 				room(Tag("Object", single=False, attr=attr))
@@ -323,7 +323,7 @@ def write_html(scene, filepath, path_mode):
 				assetsound = Tag("AssetSound", attr=[("id", name), ("src",name)])
 				if not assetsound in assets:
 					assets(assetsound)
-					shutil.copyfile(src=o.janus_object_sound, dst=os.path.join(filepath, name))
+					shutil.copyfile(src=bpy.path.abspath(o.janus_object_sound), dst=os.path.join(filepath, name))
 				sound = Tag("Sound", attr=[("id", name), ("js_id", o.janus_object_jsid), ("pos", p2s(o.location)), ("dist", f2s(o.janus_object_sound_dist)), ("rect", v2s(list(o.janus_object_sound_xy1)+list(o.janus_object_sound_xy2))), ("loop", b2s(o.janus_object_sound_loop)), ("play_once", b2s(o.janus_object_sound_once))])
 				room(sound)
 				

--- a/vr_export.py
+++ b/vr_export.py
@@ -40,9 +40,11 @@ def r2s(m):
 # Moved here from the original code in the MESH handler
 # Used for links based on placeholder planes.
 # Notably, I assume Euler X 90 YZ 0 is a standing link.
-def ir(attr, m):
-	rot = [" ".join([str(f) for f in list(v.xyz)]) for v in m.normalized()]
-	attr += [("xdir", rot[0]), ("ydir", rot[1]), ("zdir", rot[2]),]
+# (Later) this turned to be somewhat wrong, fixing it now.
+# Code still here in case this setup is useful for something.
+#def ir(attr, m):
+#	rot = [" ".join([str(f) for f in list(v.xyz)]) for v in m.normalized()]
+#	attr += [("xdir", rot[0]), ("ydir", rot[1]), ("zdir", rot[2]),]
 
 # Yes, it's probably inefficient, but I already tried messing around 
 #  with the function seen in ir, and it was painful.
@@ -57,6 +59,12 @@ def mtm(attr, m):
 	attr += [("xdir", p2s(list(m*Vector([-1,0,0,0]))[:3]))]
 	attr += [("ydir", p2s(list(m*Vector([0,0,1,0]))[:3]))]
 	attr += [("zdir", p2s(list(m*Vector([0,-1,0,0]))[:3]))]
+
+# And links.
+def mtl(attr, m):
+	attr += [("xdir", p2s(list(m*Vector([1,0,0,0]))[:3]))]
+	attr += [("ydir", p2s(list(m*Vector([0,1,0,0]))[:3]))]
+	attr += [("zdir", p2s(list(m*Vector([0,0,1,0]))[:3]))]
 
 def write_html(scene, filepath, path_mode):
 
@@ -293,9 +301,17 @@ def write_html(scene, filepath, path_mode):
 			elif o.janus_object_objtype == "JOT_LINK":
 				# Link is a separate object type now, allowing plane placeholders to allow some semblance of visual editing.
 				# portalaccounting deals with the fact Janus portals are centred at their bottom middle, not the centre like a plane placeholder
-				portalaccounting = (o.matrix_local * Vector([0.0, -(o.scale.x / 2.0), 0.0, 0.0])).xyz
-				attr = [("pos",p2s(o.location+portalaccounting)), ("scale",v2s(o.scale * 2.0)), ("url",o.janus_object_link_url), ("title",o.janus_object_link_name), ("col", v2s(o.color[:3]))]
-				ir(attr, o.matrix_local)
+				portalaccounting = (o.matrix_local.normalized() * Vector([0.0, -o.scale.y, -0.1, 0.0])).xyz
+				# leave an Empty marker for debug?
+				# for now just ruin state
+				# Scaling:
+				# ideal input is 1.58, 1.77
+				# ideal output is 3.06, 3.35, 1 approx???
+				# note; actual ratios used are post-portal position adjustments.
+				# 
+				attr = [("pos",p2s(o.location+portalaccounting)), ("url",o.janus_object_link_url), ("title",o.janus_object_link_name), ("col", v2s(o.color[:3]))]
+				attr += [("scale",v2s(Vector([o.scale.x * 1.93, o.scale.y * 2.00, 1.0])))]
+				mt2(attr, o.matrix_local)
 				if o.janus_object_jsid:
 					attr += [("js_id",o.janus_object_jsid)]
 				if not o.janus_object_active:

--- a/vr_export.py
+++ b/vr_export.py
@@ -52,23 +52,19 @@ def r2sr(m):
 
 # Yes, it's probably inefficient, but I already tried messing around 
 #  with the function seen in ir, and it was painful.
-# This one's used for text.
+# This one's used for text and links.
 def mt2(attr, m):
+	m = m.normalized()
 	attr += [("xdir", p2s(list(m*Vector([1,0,0,0]))[:3]))]
 	attr += [("ydir", p2s(list(m*Vector([0,1,0,0]))[:3]))]
 	attr += [("zdir", p2s(list(m*Vector([0,0,1,0]))[:3]))]
 
 # Here's one that's used for models.
 def mtm(attr, m):
+	m = m.normalized()
 	attr += [("xdir", p2s(list(m*Vector([-1,0,0,0]))[:3]))]
 	attr += [("ydir", p2s(list(m*Vector([0,0,1,0]))[:3]))]
 	attr += [("zdir", p2s(list(m*Vector([0,-1,0,0]))[:3]))]
-
-# And links.
-def mtl(attr, m):
-	attr += [("xdir", p2s(list(m*Vector([1,0,0,0]))[:3]))]
-	attr += [("ydir", p2s(list(m*Vector([0,1,0,0]))[:3]))]
-	attr += [("zdir", p2s(list(m*Vector([0,0,1,0]))[:3]))]
 
 def write_html(scene, filepath, path_mode):
 

--- a/vr_export.py
+++ b/vr_export.py
@@ -36,6 +36,10 @@ def lp2s(v):
 def r2s(m):
 	return v2s(list(m*Vector([-1,0,0,0]))[:3])
 
+# rotation to string, room fwd edition
+def r2sr(m):
+	return v2s(list(m*Vector([0,0,-1,0]))[:3])
+
 # Insert rotation
 # Moved here from the original code in the MESH handler
 # Used for links based on placeholder planes.
@@ -88,7 +92,6 @@ def write_html(scene, filepath, path_mode):
 	assets = Tag("Assets")
 	
 	attr=[
-		("fwd","0 0 1"),
 		("gravity", f2s(scene.janus_room_gravity)),
 		("walk_speed", f2s(scene.janus_room_walkspeed)),
 		("run_speed", f2s(scene.janus_room_runspeed)),
@@ -117,7 +120,7 @@ def write_html(scene, filepath, path_mode):
 	if scene.camera:
 		attr += [
 		("pos", p2s(scene.camera.location)),
-		("fwd", r2s(scene.camera.matrix_local)),
+		("fwd", r2sr(scene.camera.matrix_local)),
 		]
 
 	if scene.janus_room!="None":

--- a/vr_export.py
+++ b/vr_export.py
@@ -168,6 +168,7 @@ def write_html(scene, filepath, path_mode):
 	room = Tag("Room", attr)
 	
 	useractive = scene.objects.active
+	userselect = bpy.context.selected_objects[:]
 	
 	exportedmeshes = []
 	exportedsurfaces = []
@@ -326,6 +327,10 @@ def write_html(scene, filepath, path_mode):
 				sound = Tag("Sound", attr=[("id", name), ("js_id", o.janus_object_jsid), ("pos", p2s(o.location)), ("dist", f2s(o.janus_object_sound_dist)), ("rect", v2s(list(o.janus_object_sound_xy1)+list(o.janus_object_sound_xy2))), ("loop", b2s(o.janus_object_sound_loop)), ("play_once", b2s(o.janus_object_sound_once))])
 				room(sound)
 				
+	for so in bpy.context.selected_objects:
+		so.select = False
+	for so in userselect:
+		so.select = True
 	scene.objects.active = useractive
 	
 	fire(assets)

--- a/vr_export.py
+++ b/vr_export.py
@@ -36,34 +36,27 @@ def lp2s(v):
 def r2s(m):
 	return v2s(list(m*Vector([-1,0,0,0]))[:3])
 
-# insert rotation (used to give Object-style full rotation to anything that can take it)
-# moved here from the original code in the MESH handler
-# Since there's some special logic to deal with rotation now because of axis weirdness,
-# (I'm beginning to suspect the reason for the "Apply Rotation" hack is a lazy way out of this - suffice to say, I won't have it)
+# Insert rotation
+# Moved here from the original code in the MESH handler
 # Used for links based on placeholder planes.
-# Notably, I assume Euler X -90 YZ 0 is a standing link, facing to the +Y direction. I could well be insane for thinking that -Y (blender) is forwards.
+# Notably, I assume Euler X 90 YZ 0 is a standing link.
 def ir(attr, m):
 	rot = [" ".join([str(f) for f in list(v.xyz)]) for v in m.normalized()]
 	attr += [("xdir", rot[0]), ("ydir", rot[1]), ("zdir", rot[2]),]
 
-# If anyone complains about inefficiency, they can go write their version and run it through a test suite.
-# And test using Text objects, please. Lots of them, in MANY orientations.
-# *Then* talk to me (20kdc) about it.
+# Yes, it's probably inefficient, but I already tried messing around 
+#  with the function seen in ir, and it was painful.
+# This one's used for text.
 def mt2(attr, m):
 	attr += [("xdir", p2s(list(m*Vector([1,0,0,0]))[:3]))]
 	attr += [("ydir", p2s(list(m*Vector([0,1,0,0]))[:3]))]
 	attr += [("zdir", p2s(list(m*Vector([0,0,1,0]))[:3]))]
 
-# Here's one that works for models.
+# Here's one that's used for models.
 def mtm(attr, m):
 	attr += [("xdir", p2s(list(m*Vector([-1,0,0,0]))[:3]))]
 	attr += [("ydir", p2s(list(m*Vector([0,0,1,0]))[:3]))]
 	attr += [("zdir", p2s(list(m*Vector([0,-1,0,0]))[:3]))]
-
-# Possible swaps:
-# 0, 1: FAIL
-# 2, 1: FAIL
-# 0, 2: FAIL
 
 def write_html(scene, filepath, path_mode):
 

--- a/vr_export.py
+++ b/vr_export.py
@@ -228,14 +228,14 @@ def write_html(scene, filepath, path_mode):
 				
 				#bpy.ops.object.select_pattern(pattern=o.name, extend=False) # This apparently doesn't work on 2.78?
 				# Things to hardcode in the name of accident prevention:
-				# 1. Force export_scene.obj to use -Z Forward, Y Up, if it's currently using user defaults instead.
+				# 1. Force export_scene.obj to use -Z Forward, Y Up, if it's currently using user defaults instead. [done]
 				# 2. Figure out what's up with the COLLADA exporter (and force coordinate-related settings)
 				
 				if not o.data.name in exportedmeshes:
 					epath = os.path.join(filepath, o.data.name+scene.janus_object_export)
 					if scene.janus_object_export==".obj":
 						with redirect_stdout(stdout):
-							bpy.ops.export_scene.obj(filepath=epath, use_selection=True, use_smooth_groups_bitflags=True, use_uvs=True, use_materials=True, use_mesh_modifiers=True,use_triangles=True, check_existing=False, use_normals=True, path_mode="COPY")
+							bpy.ops.export_scene.obj(filepath=epath, use_selection=True, use_smooth_groups_bitflags=True, use_uvs=True, use_materials=True, use_mesh_modifiers=True,use_triangles=True, check_existing=False, use_normals=True, path_mode="COPY", axis_forward='-Z', axis_up='Y')
 					else:
 						with redirect_stdout(stdout):
 							bpy.ops.wm.collada_export(filepath=epath, selected=True, check_existing=False)


### PR DESCRIPTION
This version is probably a forward-port to Blender 2.78.
Not quite sure. It might just run fine on older versions.
In any case, this ensures you probably won't have to use Apply Rotation/Apply Scale for everything.
It fixes Text Objects (for the most part), and adds a way of creating links that should be easier to use.
It seems to be working well enough in my test scene, but I'd like to see it run through a more complicated test.

(EDIT: Also note the fact this is one commit is more to do with the fact I could only really have put it into two commits anyway, one to fix everything, and one to add the special link support.)